### PR TITLE
Arduino ISP  'speed' and 'protocol'  setting

### DIFF
--- a/dists/diy_atmega8_series/avr/boards.txt
+++ b/dists/diy_atmega8_series/avr/boards.txt
@@ -210,6 +210,14 @@ atmega48_diy.menu.boot.optiboot.upload.maximum_size=3520
 atmega48_diy.menu.boot.optiboot.bootloader.high_fuses=0xDD
 atmega48_diy.menu.boot.optiboot.bootloader.file=optiboot_{build.mcu}_{build.f_cpu}_{upload.speed}.hex
 
+atmega48_diy.menu.boot.AISP=Arduino as ISP
+atmega48_diy.menu.boot.AISP.upload.protocol=stk500v1
+atmega48_diy.menu.boot.AISP.upload.speed=19200
+atmega48_diy.menu.boot.AISP.upload.maximum_size=3520
+atmega48_diy.menu.boot.AISP.bootloader.high_fuses=0xDD
+atmega48_diy.menu.boot.AISP.bootloader.file=optiboot_{build.mcu}_{build.f_cpu}_{upload.speed}.hex
+
+
 atmega48_diy.menu.boot.none=No (ISP Programmer Upload)
 atmega48_diy.menu.boot.none.upload.maximum_size=4096
 atmega48_diy.menu.boot.none.bootloader.high_fuses=0xDD


### PR DESCRIPTION
 I have tested with Arduino uno R3 as ISP to program a ATmega48pa mcu, which resulted in the following error : 
"stk500_getsync() attempt 2 of 10: not in sync: resp=0x1c"

The error does not occurs while uploading the bootloader, but only when uploading sketches. 
So i noticed the difference between  commands and singled out the problem causing settings(speed,protocol). 

However i am a beginner, that is why i added the new settings as a new menu option.

tested on Arduino IDE 1.6.4
