### PR TITLE
Add missing shell scripts for exporting hex files

### DIFF
--- a/dists/diy_attiny/avr/delete_merged_output.bat
+++ b/dists/diy_attiny/avr/delete_merged_output.bat
@@ -1,0 +1,2 @@
+@echo off
+if "%1" == "false" del "%2"

--- a/dists/diy_attiny/avr/delete_merged_output.sh
+++ b/dists/diy_attiny/avr/delete_merged_output.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+if [ "$1" == "false" ]; then
+  rm "$2"
+fi


### PR DESCRIPTION
Few shell script missing from the current repo, I did a hotfix for this issue. Please merge

## Issue

Step 1: Trying to export the hex: `Sketch -> Export compiled Binary`
Step 2: Be sad because the error:
```
Sketch uses 792 bytes (77%) of program storage space. Maximum is 1024 bytes.
Global variables use 18 bytes (28%) of dynamic memory, leaving 46 bytes for local variables. Maximum is 64 bytes.
chmod: /Users/lazly/Library/Arduino15/packages/diy_attiny/hardware/avr/2018.3.11/delete_merged_output.sh: No such file or directory
Error compiling.
```

## Reason

https://github.com/sleemanj/ATTinyCore/blob/94d91ffb3123fd3a271eac9c24a385a2cff7a5a1/avr/platform.txt#L103-L107

## Solution

Find the missing script, and copy here
Source: Copy from https://github.com/sleemanj/ATTinyCore/tree/master/avr